### PR TITLE
Clarification on Accesses API usage.

### DIFF
--- a/documentation/API_documentation/DedicatedNetworks_GeneralDescription.md
+++ b/documentation/API_documentation/DedicatedNetworks_GeneralDescription.md
@@ -61,6 +61,8 @@ A high-level sequence of steps involved when using Dedicated Network APIs is dep
     C --> D
 ```
 
+An Access resource for a device can be created once the Network resource is created. An Access resource cannot be created anymore, once the Network is in TERMINATED [state](#states-of-the-network).
+
 ## Pre-requisites
 
 Before Dedicated Network APIs can be invoked, relevant agreements need to be in place between the API Consumer and the API Provider. Conceptually, the agreement contains all the different terms and conditions, which typically include price, service descriptions and conditions. It also includes obligations and restrictions possibly for both, the API Provider and the API Consumer, etc.


### PR DESCRIPTION
A clarification is added that the Accesses API can only be used once the Network resource is created and not yet in TERMINATED state.

#### What type of PR is this?

Add one of the following kinds:
* documentation


#### What this PR does / why we need it:
The PR clarifies that an Access resource can only be created once a Network is created. When the Network is in TERMINATED state, creation of Access resources is not possible anymore for the given Network.



#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.-->

Fixes: [#45](https://github.com/camaraproject/DedicatedNetworks/issues/45)


#### Special notes for reviewers:



#### Changelog input

```
The PR clarifies that an Access resource can only be created once a Network is created. When the Network is in TERMINATED state, creation of Access resources is not possible anymore for the given Network.

```

#### Additional documentation 

This section can be blank.



```
docs

```
