### PR TITLE
Clarification of QOS Profiles

### DIFF
--- a/code/API_definitions/dedicated-network-accesses.yaml
+++ b/code/API_definitions/dedicated-network-accesses.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: Dedicated Network - Accesses
   description: |
-    This API allows for requesting network access for devices. A device is identified by the CAMARA _device object_, containing either an MSIDSN or a Network Access Identifier.
+    This API allows for requesting network access for devices. A device is identified by the CAMARA _device object_, containing either an MSIDSN or a Network Access Identifier. For more information about the Dedicated Networks APIs, see the _GeneralDescription_ document in the Dedicated Networks [repository](https://github.com/camaraproject/DedicatedNetworks/).
 
     A Device Access represents the permission for a specific device to use a Dedicated Network's reserved connectivity resources. Only devices for which a Device Access resource has been created can use the connectivity resources allocated for that network. The usage of resources can be tailored to each device within the constraints of the applicable Network Profile.
 
@@ -37,7 +37,7 @@ info:
 
     - identifier of the device - either in `device` object or in the token (see "Identifying the device from the access token" above)
 
-    - optionally, a default QoS Profile can be set for the device
+    - optionally, a default QoS Profile can be set for the device (see Network Profiles section in the dedicated-network-profiles API in the [Dedicated Networks repository](https://github.com/camaraproject/DedicatedNetworks/)).
 
     - optionally, a subset of QoS Profiles from this network can be provided to further restrict which QoS Profiles the device can access
 

--- a/code/API_definitions/dedicated-network-profiles.yaml
+++ b/code/API_definitions/dedicated-network-profiles.yaml
@@ -3,11 +3,21 @@ info:
   title: Dedicated Network - Network Profiles
   description: |
 
+    # Introduction 
+
     This API allows for discovering available network profiles, which are offered by the network provider to be used in conjunction of the Dedicated Network API. Network profiles describe the capabilities and performance targets of a dedicated network. For more information about the Dedicated Networks APIs, see [link]().
+
+    # Network Profiles
 
     A Network Profile represents a predefined set of network capabilities and performance characteristics that can be applied when creating a Network. It enables API Consumers to understand the capabilities they can expect when using the reserved network connectivity resources. A Network Profile is a validated, supported configuration that has been pre-approved between the API Provider and API Consumer.
 
-    A Network Profile contains information about the maximum number of devices allowed, the aggregated throughput to be provided, and a set of allowed QoS Profiles that devices can use when having access to the Dedicated Network. A detailed description of the individual parameters may be included within the _terms and conditions_ (outside of scope for the API).
+    A Network Profile contains information about the maximum number of devices allowed, the aggregated throughput to be provided, and a set of allowed QoS Profiles that devices can use when having access to the Dedicated Network. The concept of named QoS Profiles is re-used from the [QualityOnDemand](https://github.com/camaraproject/QualityOnDemand) API family. 
+      * An API provider may offer the QualityOnDemand `qoS-profiles` API for resolving a QoS Profile name into characteristics of a specific QoS profile.
+      * When multiple QoS Profiles are supported within one Network Profile, the QualityOnDemand `quality-on-demand` API may be used while the Network is in ACTIVATED state.
+
+    A detailed description of the individual parameters may be included within the _terms and conditions_ (outside of scope for the API).
+
+    # Network Profiles API
 
     The key characteristics of the API include:
 

--- a/code/API_definitions/dedicated-network-profiles.yaml
+++ b/code/API_definitions/dedicated-network-profiles.yaml
@@ -3,7 +3,7 @@ info:
   title: Dedicated Network - Network Profiles
   description: |
 
-    # Introduction 
+    # Introduction
 
     This API allows for discovering available network profiles, which are offered by the network provider to be used in conjunction of the Dedicated Network API. Network profiles describe the capabilities and performance targets of a dedicated network. For more information about the Dedicated Networks APIs, see [link]().
 
@@ -11,7 +11,7 @@ info:
 
     A Network Profile represents a predefined set of network capabilities and performance characteristics that can be applied when creating a Network. It enables API Consumers to understand the capabilities they can expect when using the reserved network connectivity resources. A Network Profile is a validated, supported configuration that has been pre-approved between the API Provider and API Consumer.
 
-    A Network Profile contains information about the maximum number of devices allowed, the aggregated throughput to be provided, and a set of allowed QoS Profiles that devices can use when having access to the Dedicated Network. The concept of named QoS Profiles is re-used from the [QualityOnDemand](https://github.com/camaraproject/QualityOnDemand) API family. 
+    A Network Profile contains information about the maximum number of devices allowed, the aggregated throughput to be provided, and a set of allowed QoS Profiles that devices can use when having access to the Dedicated Network. The concept of named QoS Profiles is re-used from the [QualityOnDemand](https://github.com/camaraproject/QualityOnDemand) API family.
       * An API provider may offer the QualityOnDemand `qoS-profiles` API for resolving a QoS Profile name into characteristics of a specific QoS profile.
       * When multiple QoS Profiles are supported within one Network Profile, the QualityOnDemand `quality-on-demand` API may be used while the Network is in ACTIVATED state.
 

--- a/code/API_definitions/dedicated-network-profiles.yaml
+++ b/code/API_definitions/dedicated-network-profiles.yaml
@@ -12,8 +12,8 @@ info:
     A Network Profile represents a predefined set of network capabilities and performance characteristics that can be applied when creating a Network. It enables API Consumers to understand the capabilities they can expect when using the reserved network connectivity resources. A Network Profile is a validated, supported configuration that has been pre-approved between the API Provider and API Consumer.
 
     A Network Profile contains information about the maximum number of devices allowed, the aggregated throughput to be provided, and a set of allowed QoS Profiles that devices can use when having access to the Dedicated Network. The concept of named QoS Profiles is re-used from the [QualityOnDemand](https://github.com/camaraproject/QualityOnDemand) API family.
-      * An API provider may offer the QualityOnDemand `qoS-profiles` API for resolving a QoS Profile name into characteristics of a specific QoS profile.
-      * When multiple QoS Profiles are supported within one Network Profile, the QualityOnDemand `quality-on-demand` API may be used while the Network is in ACTIVATED state.
+      * An API provider may offer the QualityOnDemand `qos-profiles` API for resolving a QoS Profile name into characteristics of a specific QoS profile.
+      * When multiple QoS Profiles are supported within one Network Profile, the QualityOnDemand `quality-on-demand` API may be used to assign one of the available QoS profiles to a specific device while the Network is in ACTIVATED state .
 
     A detailed description of the individual parameters may be included within the _terms and conditions_ (outside of scope for the API).
 

--- a/documentation/API_documentation/DedicatedNetworks_GeneralDescription.md
+++ b/documentation/API_documentation/DedicatedNetworks_GeneralDescription.md
@@ -41,8 +41,13 @@ The APIs are summarized in the table below followed by a brief description. Deta
 | **API** | **Purpose of the API** | **Key Abstractions and concepts** |
 | ---- | ------- | ----|
 | Dedicated Network API | Reservation and lifecycle management of network connectivity resources for dedicated use. | A Dedicated Network is a logical resource and is used to embody the reservation of network connectivity resources in the physical network. Initiating a new reservation request using this API results in a new Dedicated Network resource being created. The Dedicated Network undergoes various lifecycle States including REQUESTED, RESERVED, ACTIVATED and TERMINATED. Reservation of resources occurs based on the selected Network Profile, duration when the reservation is needed (Service Time) and geographical areas where the service is needed (Service Area). |
-| Dedicated Network Profiles API | Discovery of predefined set of network capabilities and performance characteristics | A Network Profile represents a predefined set of network capabilities and performance characteristics that can be applied when creating dedicated networks. Each profile represents a validated, supported configuration that has been pre-approved in the terms and conditions between the API Provider and API Consumer. |
+| Dedicated Network Profiles API | Discovery of predefined set of network capabilities and performance characteristics | A Network Profile represents a predefined set of network capabilities and performance characteristics that can be applied when creating dedicated networks. Each profile represents a validated, supported configuration that has been pre-approved in the _terms and conditions_ between the API Provider and API Consumer. |
 | Dedicated Network Accesses API | Managing access to the Dedicated Network, i.e., controlling which devices may benefit from the reserved resources and capabilities | A Device Access represents the permission for a specific device to use a Dedicated Network's reserved connectivity resources. The usage of resources can be tailored to each device within the constraints of the applicable Network Profile. |
+
+The Accesses and the Network Profile re-use the concept of named QoS Profiles from [QualityOnDemand](https://github.com/camaraproject/QualityOnDemand) for describing connectivity performance characteristics. An API provider may offer the `qos-profiles` API for resolving a QoS Profile name into characteristics of a specific QoS profile. 
+
+When multiple QoS profiles are defined within a Network Profile, the API Consumer may either statically assign a different QoS profile (from the set of QoS profiles) for each device access or may dynamically create QoS Sessions using the QualityOnDemand `quality-on-demand` API.
+The API Consumer may also restict the list of possible QoS Profiles within a Device Access.
 
 A high-level sequence of steps involved when using Dedicated Network APIs is depicted in the diagram below and further described in their respective sections.
 
@@ -98,13 +103,13 @@ sequenceDiagram
     participant Network as Physical Network
     participant D as Device(s)
     Note over App,D: Pre-requisites completed
-    rect lightcyan
-        note right of App: Selection of Profile needed for Dedicated Network
+    rect black
+        note right of App: 1: Reading Profiles
         App->>P: GET /profiles
         P->>App: 200 OK Profiles [profileId, ...]
     end
-    rect lightcyan
-        note right of App: Creation of a Dedicated Network
+    rect black
+        note right of App: 2: Creating a Dedicated Network
         App->>N: POST /networks (profileId, serviceArea, serviceTime, ...)
         N->>App: 201 ACCEPTED (networkId, status=REQUESTED)
          N <<-->> Network: Provisioning / configuration as needed<br> Managed by API Provider and Network Provider<br>  Outside scope of the Dedicated Network APIs
@@ -116,8 +121,8 @@ sequenceDiagram
             N-->>App: 200 OK (networkId, status=ACTIVATED)
         end
     end
-    rect lightcyan
-        note right of App: Dedicated Network Accesses API
+    rect black
+        note right of App: 3: Managing Device Access
         loop Create Access resource for a given device to the given network
             App->>A: POST /accesses (networkId, device)
             A->>App: 200 OK Access created (accessId)
@@ -128,12 +133,26 @@ sequenceDiagram
             A->>App: 200 OK Access deleted
         end
     end
-    Note over App,D: While Dedicated Network in ACTIVATED state
+    Note over App,D: 4: Dedicated Network in ACTIVATED state
     loop One or more devices
         D-->>Network: Connect to network
         Network-->>D: Connection established / denied
     end
 ```
+
+Description of main steps
+1. Reading Profiles: The API Consumer is reading the eligible Network Profiles. Each Network Profile contains properties, like aggregated throughput or QOS profiles.
+    * The terms and conditions (see [Pre-requisites](#pre-requisites)) may define the conditions, constrains, etc for using the profile.
+1. Creating a Dedicated Network: The API Consumer creates a network, providing the profile, service time and service area as input parameters
+    * The network is initially in REQUESTED state. See [network lifecycle](#states-of-the-network) for more information.
+    * The API Consumer can register a sink for receiving network state changes.
+1.  Managing Device Access: The API Consumer may allow one or more devices to get access to the capabilities and pcapacity of the network
+    * The API Consumer may use the Accesses API, while the network is either in REQUESTED, RESERVED or ACTIVATED state. The API Consumer gets an error code, when using the Accesses API with a Network in TERMINATED state.
+        * Creating an Access resource corresponds to giving access for a device to the network.
+        * Deleting an Access resource corresponds to revoking access for a device to the network.
+1.  When Dedicated Network is in ACTIVATED state: Devices with access will be able to connect to the network.
+    * When a default QoS profile is defined within the Network Profile (or changed via the Access resources), the all traffic of the device will be treated with this QoS profile as default
+    * When multiple QoS profiles are defined within the Network Profile (or changed via the Access resources), the API Consumer may use the QOD API for managing QoS Sessions with the QoS Profiles listed in the Network Profile.
 
 ## States of the network
 


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* documentation


#### What this PR does / why we need it:
The PR clarifies, that the Dedicated Networks APIs reuse the QualityOnDemand QOS Profiles concept.
Note, this PR not only addresses the QOS Profile clarifications within the Network Profiles API, but also in the Accesses API and the General description.
The background color in the sequence diagram is changed to increase readability.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes [#48](https://github.com/camaraproject/DedicatedNetworks/issues/48)

#### Special notes for reviewers:



#### Changelog input

```
the documentation (info section in profiles & accesses API and general documentation) is extended to clarify, that the Dedicated Networks APIs reuse the QualityOnDemand QOS Profiles concept. 

```

#### Additional documentation 

This section can be blank.



```
docs

```
