### PR TITLE
Clarification of Device Object usage

### DIFF
--- a/code/API_definitions/dedicated-network-accesses.yaml
+++ b/code/API_definitions/dedicated-network-accesses.yaml
@@ -2,9 +2,15 @@ openapi: 3.0.3
 info:
   title: Dedicated Network - Accesses
   description: |
-    This API allows for requesting network access for devices. A device is identified by the CAMARA _device object_, containing either an MSIDSN or a Network Access Identifier.
-
+    This API allows for requesting network access for devices.
+   
     A Device Access represents the permission for a specific device to use a Dedicated Network's reserved connectivity resources. Only devices for which a Device Access resource has been created can use the connectivity resources allocated for that network. The usage of resources can be tailored to each device within the constraints of the applicable Network Profile.
+
+    A device is identified by the CAMARA `device` object, where at least one identifier for the device (user equipment) out of four options: IPv4 address, IPv6 address, Phone number, or Network Access Identifier assigned by the mobile network operator for the device.
+
+    Notes:
+    1. Support for using an IP address as device identifier is not recommended when the IP address may change. The API invoker may not be able to associate the accesses resource with the targeted device anymore.<br>Further, the device may be offline at time of Accesses API usage, thus, no IP address assigned.
+    1. Network Access Identifier is defined for future use and will not be supported with this version of the API.
 
     # Authorization and authentication
 
@@ -302,16 +308,22 @@ components:
       description: |
         End-user equipment able to connect to a mobile network. Examples of devices include smartphones or IoT sensors/actuators.
             The developer can choose to provide the below specified device identifiers:
+            * `ipv4Address`
+            * `ipv6Address`
             * `phoneNumber`
             * `networkAccessIdentifier`
             NOTE1: the network operator might support only a subset of these options. The API invoker can provide multiple identifiers to be compatible across different network operators. In this case the identifiers MUST belong to the same device.
-            NOTE2: As for this Commonalities release, we are enforcing that the networkAccessIdentifier is only part of the schema for future-proofing, and CAMARA does not currently allow its use. After the CAMARA meta-release work is concluded and the relevant issues are resolved, its use will need to be explicitly documented in the guidelines.
+            NOTE2: as for this Commonalities release, we are enforcing that the networkAccessIdentifier is only part of the schema for future-proofing, and CAMARA does not currently allow its use. After the CAMARA meta-release work is concluded and the relevant issues are resolved, its use will need to be explicitly documented in the guidelines.
       type: object
       properties:
         phoneNumber:
           $ref: "#/components/schemas/PhoneNumber"
         networkAccessIdentifier:
           $ref: "#/components/schemas/NetworkAccessIdentifier"
+        ipv4Address:
+          $ref: "#/components/schemas/DeviceIpv4Addr"
+        ipv6Address:
+          $ref: "#/components/schemas/DeviceIpv6Address"
       minProperties: 1
 
     PhoneNumber:
@@ -324,6 +336,49 @@ components:
       description: A public identifier addressing a subscription in a mobile network. In 3GPP terminology, it corresponds to the GPSI formatted with the External Identifier ({Local Identifier}@{Domain Identifier}). Unlike the telephone number, the network access identifier is not subjected to portability ruling in force, and is individually managed by each operator.
       type: string
       example: "123456789@domain.com"
+
+    DeviceIpv4Addr:
+      type: object
+      description: |
+        The device should be identified by either the public (observed) IP address and port as seen by the application server, or the private (local) and any public (observed) IP addresses in use by the device (this information can be obtained by various means, for example from some DNS servers).
+
+        If the allocated and observed IP addresses are the same (i.e. NAT is not in use) then  the same address should be specified for both publicAddress and privateAddress.
+
+        If NAT64 is in use, the device should be identified by its publicAddress and publicPort, or separately by its allocated IPv6 address (field ipv6Address of the Device object)
+
+        In all cases, publicAddress must be specified, along with at least one of either privateAddress or publicPort, dependent upon which is known. In general, mobile devices cannot be identified by their public IPv4 address alone.
+      properties:
+        publicAddress:
+          $ref: "#/components/schemas/SingleIpv4Addr"
+        privateAddress:
+          $ref: "#/components/schemas/SingleIpv4Addr"
+        publicPort:
+          $ref: "#/components/schemas/Port"
+      anyOf:
+        - required: [publicAddress, privateAddress]
+        - required: [publicAddress, publicPort]
+      example:
+        publicAddress: "84.125.93.10"
+        publicPort: 59765
+
+    SingleIpv4Addr:
+      description: A single IPv4 address with no subnet mask
+      type: string
+      format: ipv4
+      example: "84.125.93.10"
+
+    Port:
+      description: TCP or UDP port number
+      type: integer
+      minimum: 0
+      maximum: 65535
+
+    DeviceIpv6Address:
+      description: |
+        The device should be identified by the observed IPv6 address, or by any single IPv6 address from within the subnet allocated to the device (e.g. adding ::0 to the /64 prefix).
+      type: string
+      format: ipv6
+      example: 2001:db8:85a3:8d3:1319:8a2e:370:7344
 
     ErrorInfo:
       type: object

--- a/documentation/API_documentation/DedicatedNetworks_GeneralDescription.md
+++ b/documentation/API_documentation/DedicatedNetworks_GeneralDescription.md
@@ -24,6 +24,9 @@ Detailed characteristics, behaviors and costs pertaining to Dedicated Networks a
 
 An API Provider realizes Dedicated Networks based on the physical network resources managed by a Network Provider. An API Provider can be the Network Provider.
 
+The present set of [Usage Scenarios](../SupportingDocuments/UsageScenarios.md) focuses on B2B use-cases, where the owner of the devices / device subscriptions is also acting as API invoker for the Networks and the Accesses APIs. This constellation allows using using the MSISDN as device identifier with a two-legged access tokens, since no additional consent needs to be obtained.
+
+
 **Key roles**
 
 | **Role Name** | **Description** |


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* documentation


#### What this PR does / why we need it:
This PR adds some reasoning, why the Device Object does not support IP Addresses, as in other CAMARA APIs.



#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes [#49](https://github.com/camaraproject/DedicatedNetworks/issues/49)

#### Special notes for reviewers:



#### Changelog input

```
Addition of some reasoning, why the Device Object (Access API) does not support IP Addresses for device identification, as in other CAMARA APIs
```

#### Additional documentation 

This section can be blank.



```
docs

```
