### PR TITLE
Reset versions in API and test definitions back to wip after r1.1

### DIFF
--- a/code/API_definitions/dedicated-network-accesses.yaml
+++ b/code/API_definitions/dedicated-network-accesses.yaml
@@ -66,13 +66,13 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.1.0-rc.1
+  version: wip
   x-camara-commonalities: 0.6
 externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/DedicatedNetworks
 servers:
-  - url: "{apiRoot}/dedicated-network-accesses/v0.1rc1"
+  - url: "{apiRoot}/dedicated-network-accesses/vwip"
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/API_definitions/dedicated-network-profiles.yaml
+++ b/code/API_definitions/dedicated-network-profiles.yaml
@@ -40,13 +40,13 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.1.0-rc.1
+  version: wip
   x-camara-commonalities: 0.6
 externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/DedicatedNetworks
 servers:
-  - url: "{apiRoot}/dedicated-network-profiles/v0.1rc1"
+  - url: "{apiRoot}/dedicated-network-profiles/vwip"
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/API_definitions/dedicated-network.yaml
+++ b/code/API_definitions/dedicated-network.yaml
@@ -52,13 +52,13 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.1.0-rc.1
+  version: wip
   x-camara-commonalities: 0.6
 externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/DedicatedNetworks
 servers:
-  - url: "{apiRoot}/dedicated-network/v0.1rc1"
+  - url: "{apiRoot}/dedicated-network/vwip"
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/Test_definitions/dedicated-network-accesses.feature
+++ b/code/Test_definitions/dedicated-network-accesses.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Dedicated Network API, 0.1.0-rc.1 - Network Accesses API Operations
+Feature: CAMARA Dedicated Network API, wip - Network Accesses API Operations
     # Input to be provided by the implementation to the tester
     #
     # Implementation indications:
@@ -20,7 +20,7 @@ Feature: CAMARA Dedicated Network API, 0.1.0-rc.1 - Network Accesses API Operati
 
     @dedicated_network_accesses_listNetworkAccesses_01_success_all
     Scenario: List all network accesses
-        Given the resource "/dedicated-network-accesses/v0.1rc1/accesses"
+        Given the resource "/dedicated-network-accesses/vwip/accesses"
         When the request "listNetworkAccesses" is sent
         Then the response status code is 200
         And the response header "Content-Type" is "application/json"
@@ -30,7 +30,7 @@ Feature: CAMARA Dedicated Network API, 0.1.0-rc.1 - Network Accesses API Operati
     @dedicated_network_accesses_listNetworkAccesses_02_success_filtered_by_network
     Scenario: List network accesses filtered by network ID
         Given an existing dedicated network
-        And the resource "/dedicated-network-accesses/v0.1rc1/accesses"
+        And the resource "/dedicated-network-accesses/vwip/accesses"
         And the query parameter "networkId" is set to the ID of the existing network
         When the request "listNetworkAccesses" is sent
         Then the response status code is 200
@@ -42,7 +42,7 @@ Feature: CAMARA Dedicated Network API, 0.1.0-rc.1 - Network Accesses API Operati
     @dedicated_network_accesses_listNetworkAccesses_03_success_filtered_by_device
     Scenario: List network accesses filtered by device
         Given a valid device identifier
-        And the resource "/dedicated-network-accesses/v0.1rc1/accesses"
+        And the resource "/dedicated-network-accesses/vwip/accesses"
         And the header "x-device" is set to a RFC 8941 structured field value representing the Device schema (#/components/schemas/Device) (e.g., 'phonenumber="+123456789"')
         When the request "listNetworkAccesses" is sent
         Then the response status code is 200
@@ -56,7 +56,7 @@ Feature: CAMARA Dedicated Network API, 0.1.0-rc.1 - Network Accesses API Operati
     @dedicated_network_accesses_createNetworkAccess_01_success
     Scenario: Create a network access with valid parameters
         Given an existing dedicated network
-        And the resource "/dedicated-network-accesses/v0.1rc1/accesses"
+        And the resource "/dedicated-network-accesses/vwip/accesses"
         And the header "Content-Type" is set to "application/json"
         And the header "x-device" is set to a RFC 8941 structured field value representing the Device schema (#/components/schemas/Device) (e.g., 'phonenumber="+123456789"')
         And the request body is set to a request body compliant with the schema at "/components/schemas/CreateNetworkAccess"
@@ -76,7 +76,7 @@ Feature: CAMARA Dedicated Network API, 0.1.0-rc.1 - Network Accesses API Operati
     @dedicated_network_accesses_readNetworkAccess_01_success
     Scenario: Get details of a specific network access
         Given an existing network access
-        And the resource "/dedicated-network-accesses/v0.1rc1/accesses/{accessId}"
+        And the resource "/dedicated-network-accesses/vwip/accesses/{accessId}"
         And the path parameter "accessId" is set to the ID of the existing access
         When the request "readNetworkAccess" is sent
         Then the response status code is 200
@@ -90,7 +90,7 @@ Feature: CAMARA Dedicated Network API, 0.1.0-rc.1 - Network Accesses API Operati
     @dedicated_network_accesses_deleteNetworkAccess_01_success
     Scenario: Delete a network access
         Given an existing network access
-        And the resource "/dedicated-network-accesses/v0.1rc1/accesses/{accessId}"
+        And the resource "/dedicated-network-accesses/vwip/accesses/{accessId}"
         And the path parameter "accessId" is set to the ID of the existing access
         When the request "deleteNetworkAccess" is sent
         Then the response status code is 204

--- a/code/Test_definitions/dedicated-network-profiles.feature
+++ b/code/Test_definitions/dedicated-network-profiles.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Dedicated Network API, 0.1.0-rc.1 - Network Profiles API Operations
+Feature: CAMARA Dedicated Network API, wip - Network Profiles API Operations
     # Input to be provided by the implementation to the tester
     #
     # Implementation indications:
@@ -18,7 +18,7 @@ Feature: CAMARA Dedicated Network API, 0.1.0-rc.1 - Network Profiles API Operati
 
     @dedicated_network_profiles_readNetworkProfiles_01_success
     Scenario: List all available network profiles
-        Given the resource "/dedicated-network-profiles/v0.1rc1/profiles"
+        Given the resource "/dedicated-network-profiles/vwip/profiles"
         When the request "readNetworkProfiles" is sent
         Then the response status code is 200
         And the response header "Content-Type" is "application/json"
@@ -31,7 +31,7 @@ Feature: CAMARA Dedicated Network API, 0.1.0-rc.1 - Network Profiles API Operati
     @dedicated_network_profiles_readNetworkProfile_01_success
     Scenario: Get details of a specific network profile
         Given an existing network profile
-        And the resource "/dedicated-network-profiles/v0.1rc1/profiles/{profileId}"
+        And the resource "/dedicated-network-profiles/vwip/profiles/{profileId}"
         And the path parameter "profileId" is set to the ID of the existing profile
         When the request "readNetworkProfile" is sent
         Then the response status code is 200

--- a/code/Test_definitions/dedicated-network.feature
+++ b/code/Test_definitions/dedicated-network.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Dedicated Network API, 0.1.0-rc.1 - Networks API Operations
+Feature: CAMARA Dedicated Network API, wip - Networks API Operations
     # Input to be provided by the implementation to the tester
     #
     # Implementation indications:
@@ -20,7 +20,7 @@ Feature: CAMARA Dedicated Network API, 0.1.0-rc.1 - Networks API Operations
 
     @dedicated_network_listNetworks_01_success
     Scenario: List all dedicated networks
-        Given the resource "/dedicated-network/v0.1rc1/networks"
+        Given the resource "/dedicated-network/vwip/networks"
         When the request "listNetworks" is sent
         Then the response status code is 200
         And the response header "Content-Type" is "application/json"
@@ -31,7 +31,7 @@ Feature: CAMARA Dedicated Network API, 0.1.0-rc.1 - Networks API Operations
 
     @dedicated_network_createNetwork_01_success
     Scenario: Create a dedicated network with valid parameters
-        Given the resource "/dedicated-network/v0.1rc1/networks"
+        Given the resource "/dedicated-network/vwip/networks"
         And the header "Content-Type" is set to "application/json"
         And the request body is set to a request body compliant with the schema at "/components/schemas/CreateNetwork"
         And the request body property "$.profileId" is set to a valid network profile ID
@@ -58,7 +58,7 @@ Feature: CAMARA Dedicated Network API, 0.1.0-rc.1 - Networks API Operations
     @dedicated_network_readNetwork_01_success
     Scenario: Get details of a specific network
         Given an existing dedicated network
-        And the resource "/dedicated-network/v0.1rc1/networks/{networkId}"
+        And the resource "/dedicated-network/vwip/networks/{networkId}"
         And the path parameter "networkId" is set to the ID of the existing network
         When the request "readNetwork" is sent
         Then the response status code is 200
@@ -72,7 +72,7 @@ Feature: CAMARA Dedicated Network API, 0.1.0-rc.1 - Networks API Operations
     @dedicated_network_deleteNetwork_01_success
     Scenario: Delete a dedicated network
         Given an existing dedicated network
-        And the resource "/dedicated-network/v0.1rc1/networks/{networkId}"
+        And the resource "/dedicated-network/vwip/networks/{networkId}"
         And the path parameter "networkId" is set to the ID of the existing network
         When the request "deleteNetwork" is sent
         Then the response status code is 204


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* subproject management


#### What this PR does / why we need it:

Setting the version in API and test definitions back to wip after r1.1 to clearly indicate that any change done between r1.1 and r1.2 does not belong to neither of the releases.

That will allow to address open issues with PRs without taking care of the version field.


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes # none (repository management)

#### Special notes for reviewers:

