### PR TITLE
Remove return code 404 from POST /networks

### DIFF
--- a/code/API_definitions/dedicated-network.yaml
+++ b/code/API_definitions/dedicated-network.yaml
@@ -170,8 +170,6 @@ paths:
           $ref: "#/components/responses/Generic401"
         "403":
           $ref: "#/components/responses/Generic403"
-        "404":
-          $ref: "#/components/responses/Generic404"
 
   /networks/{networkId}:
     get:


### PR DESCRIPTION
Endpoint will exist since it is specified. 404 therefore isnt a valid code.

#### What type of PR is this?

* bug fix / improvement



#### What this PR does / why we need it:

404 should be returned is a resource or resource collection isn't valid. In this case POST /networks is specified and must be implemented. So 404 can never be returned. 

While the PR is marked as a bug fix, it can also be seen as an improvement of specification accuracy.



#### Changelog input

```
 Removed return code 404 from POST /networks
```
