### PR TITLE
Update tests to use XCorrelator schema instead of string

### DIFF
--- a/code/Test_definitions/dedicated-network-accesses.feature
+++ b/code/Test_definitions/dedicated-network-accesses.feature
@@ -14,7 +14,7 @@ Feature: CAMARA Dedicated Network API, wip - Network Accesses API Operations
   Background: Common accesses setup
     Given an environment at "apiRoot"
     And the header "Authorization" is set to a valid access token
-    And the header "x-correlator" is set to a string value
+    And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
 
   # Success scenarios for GET /accesses
 

--- a/code/Test_definitions/dedicated-network-profiles.feature
+++ b/code/Test_definitions/dedicated-network-profiles.feature
@@ -12,7 +12,7 @@ Feature: CAMARA Dedicated Network API, wip - Network Profiles API Operations
   Background: Common profiles setup
     Given an environment at "apiRoot"
     And the header "Authorization" is set to a valid access token
-    And the header "x-correlator" is set to a string value
+    And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
 
   # Success scenarios for GET /profiles
 

--- a/code/Test_definitions/dedicated-network.feature
+++ b/code/Test_definitions/dedicated-network.feature
@@ -14,7 +14,7 @@ Feature: CAMARA Dedicated Network API, wip - Networks API Operations
   Background: Common networks setup
     Given an environment at "apiRoot"
     And the header "Authorization" is set to a valid access token
-    And the header "x-correlator" is set to a string value
+    And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
 
   # Success scenarios for GET /networks
 


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* correction



#### What this PR does / why we need it:

Based on the review feedback here: https://github.com/camaraproject/DedicatedNetworks/pull/64#discussion_r2346783767

XCorrelator Header has a schema which should be referenced instead of just using the string value

