### PR TITLE
New error code when network in wrong state

### DIFF
--- a/code/API_definitions/dedicated-network-accesses.yaml
+++ b/code/API_definitions/dedicated-network-accesses.yaml
@@ -52,6 +52,10 @@ info:
 
      which is needed to query the status of the Device Access (GET /accesses/{accessId}) and to delete Access (DELETE accesses/{accessId}).
 
+     ## Error handling:
+
+     - If the dedicated network identified by the networkId is in a wrong state when creating a device access, e.g. it is in the TERMINATED state, then the server will return an error with the `409 WRONG_STATE` error code.
+
     # Querying one or more device accesses
 
     All available device accesses of the API consumer can be queried by performing a `GET` operation on the `/accesses` endpoint. The query can be filted for accesses to a specific network (networkId) or for certain devices.
@@ -160,6 +164,8 @@ paths:
           $ref: "#/components/responses/Generic403"
         "404":
           $ref: "#/components/responses/Generic404"
+        "409":
+          $ref: "#/components/responses/Generic409"
         "422":
           $ref: "#/components/responses/Generic422"
 
@@ -528,6 +534,53 @@ components:
                 status: 404
                 code: IDENTIFIER_NOT_FOUND
                 message: Device identifier not found.
+
+    Generic409:
+      description: Conflict
+      headers:
+        x-correlator:
+          $ref: "#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 409
+                  code:
+                    enum:
+                      - ABORTED
+                      - ALREADY_EXISTS
+                      - CONFLICT
+                      - WRONG_STATE
+          examples:
+            GENERIC_409_ABORTED:
+              description: Concurreny of processes of the same nature/scope
+              value:
+                status: 409
+                code: ABORTED
+                message: Concurrency conflict.
+            GENERIC_409_ALREADY_EXISTS:
+              description: Trying to create an existing resource
+              value:
+                status: 409
+                code: ALREADY_EXISTS
+                message: The resource that a client tried to create already exists.
+            GENERIC_409_CONFLICT:
+              description: Duplication of an existing resource
+              value:
+                status: 409
+                code: CONFLICT
+                message: A specified resource duplicate entry found.
+            GENERIC_409_WRONG_STATE:
+              description: A resource referenced in the request is in a wrong state for the requested operation
+              value:
+                status: 409
+                code: WRONG_STATE
+                message: A referenced resource is in a wrong state.
 
     Generic410:
       description: Gone


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* enhancement/feature


#### What this PR does / why we need it:
This proposal adds a new error code WRONG_ACCESS to 409 generic response to indicate that a dedicated network is in a wrong state (e.g. TERMINATED) when a new device access to that network is requested. It provides clear information to the client about the reason why its request cannot be fulfilled.



#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #

#### Special notes for reviewers:



#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
