### PR TITLE
New network name property

### DIFF
--- a/code/API_definitions/dedicated-network.yaml
+++ b/code/API_definitions/dedicated-network.yaml
@@ -24,6 +24,8 @@ info:
 
     - the service start and end times (Service Time).
 
+    - Optionally, a name for the network.
+
     - Optionally, callback related information through sink and sinkCredential parameters to receive notifications about the lifecycle events of the network.
 
     The API returns a networkId. The networkId is a unique identifier of the network, which remains unchanged during its lifetime. The networkId is required when creating Device Accesses.
@@ -33,7 +35,7 @@ info:
 
     # Querying one or more Networks
 
-    All available network of the API consumer can be queried by performing a `GET` operation on the `/networks` endpoint.
+    All available network of the API consumer can be queried by performing a `GET` operation on the `/networks` endpoint. The query can be filtered for netwworks matching a certain name.
 
     A specific network of the API consumer can be queried by performing a `GET` operation on the `/networks/{networkId}` endpoint, where the networkId has been obtained during the _create_ procedure.
 
@@ -77,6 +79,11 @@ paths:
         - openId:
             - dedicated-network:networks:read
       parameters:
+        - name: name
+          in: query
+          description: name of a network
+          schema:
+            type: string
         - $ref: "#/components/parameters/x-correlator"
       responses:
         '200':
@@ -289,6 +296,9 @@ components:
       description: Common attributes of a dedicated network
       type: object
       properties:
+        name:
+          description: A human-readable name to describe the network
+          type: string
         networkProfileId:
           $ref: '#/components/schemas/NetworkProfileId'
         qosProfileName:

--- a/code/API_definitions/dedicated-network.yaml
+++ b/code/API_definitions/dedicated-network.yaml
@@ -35,7 +35,7 @@ info:
 
     # Querying one or more Networks
 
-    All available network of the API consumer can be queried by performing a `GET` operation on the `/networks` endpoint. The query can be filtered for netwworks matching a certain name.
+    All available network of the API consumer can be queried by performing a `GET` operation on the `/networks` endpoint. The query can be filtered for networks matching a certain name.
 
     A specific network of the API consumer can be queried by performing a `GET` operation on the `/networks/{networkId}` endpoint, where the networkId has been obtained during the _create_ procedure.
 


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* enhancement/feature



#### What this PR does / why we need it:
This PR makes it possibile for the API Consumer to name a dedicated network when creating it. The `name` is a new property of the dedicated network resource and is returned when the network is read or listed.  As a query parameter the `name`can be used to filter the results when getting a list of dedicated networks. The `name` property need not be unique across dedicated networks.



#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #92

#### Special notes for reviewers:



#### Changelog input

```
Allowing the API Consumer to assign an own `name` to a dedicated network resource, which is returned when the network is read or listed.  

```

#### Additional documentation 

This section can be blank.



```
docs

```
