### PR TITLE
Fix global tags for dedicted network areas and profiles

### DIFF
--- a/code/API_definitions/dedicated-network-areas.yaml
+++ b/code/API_definitions/dedicated-network-areas.yaml
@@ -70,6 +70,9 @@ servers:
       apiRoot:
         default: http://localhost:9091
         description: API root, defined by the service provider, e.g. `api.example.com` or `api.example.com/somepath`
+tags:
+  - name: Areas
+    description: Discover and read dedicated network service areas
 paths:
   /retrieve-service-areas:
     post:

--- a/code/API_definitions/dedicated-network-profiles.yaml
+++ b/code/API_definitions/dedicated-network-profiles.yaml
@@ -67,6 +67,9 @@ servers:
       apiRoot:
         default: http://localhost:9091
         description: API root, defined by the service provider, e.g. `api.example.com` or `api.example.com/somepath`
+tags:
+  - name: Profiles
+    description: Discover and read dedicated network profiles
 paths:
   /profiles:
     get:


### PR DESCRIPTION
#### What type of PR is this?
* correction

#### What this PR does / why we need it:

Adds global tags to dedicated-network-areas and dedicated-network-profiles

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #106

#### Special notes for reviewers:



#### Changelog input

```
Adding missing global tags to dedicated-network-areas and dedicated-network-profiles API definitions

```

#### Additional documentation 

This section can be blank.



```
docs

```
