### PR TITLE
Fix r2.2 sync validation errors

### DIFF
--- a/code/API_definitions/dedicated-network-accesses.yaml
+++ b/code/API_definitions/dedicated-network-accesses.yaml
@@ -786,6 +786,7 @@ components:
 
     CloudEvent:
       description: Event compliant with the CloudEvents specification
+      type: object
       required:
         - id
         - source

--- a/code/API_definitions/dedicated-network-areas.yaml
+++ b/code/API_definitions/dedicated-network-areas.yaml
@@ -77,6 +77,9 @@ paths:
         - Areas
       summary: Retrieve dedicated network service areas, filtered by additional search criteria
       operationId: retrieveNetworkServiceAreas
+      security:
+        - openId:
+            - dedicated-network-areas:areas:read
       requestBody:
         description: Parameters to query service areas
         content:
@@ -108,6 +111,9 @@ paths:
         - Areas
       summary: Read a dedicated network service area
       operationId: readNetworkServiceArea
+      security:
+        - openId:
+            - dedicated-network-areas:areas:read
       parameters:
         - name: areaId
           in: path
@@ -132,6 +138,10 @@ paths:
           $ref: "#/components/responses/Generic404"
 
 components:
+  securitySchemes:
+    openId:
+      type: openIdConnect
+      openIdConnectUrl: https://example.com/.well-known/openid-configuration
 
   headers:
     x-correlator:

--- a/code/API_definitions/dedicated-network.yaml
+++ b/code/API_definitions/dedicated-network.yaml
@@ -203,6 +203,10 @@ paths:
                 $ref: '#/components/schemas/NetworkInfo'
         '400':
           $ref: "#/components/responses/Generic400"
+        "401":
+          $ref: "#/components/responses/Generic401"
+        "403":
+          $ref: "#/components/responses/Generic403"
         '404':
           $ref: "#/components/responses/Generic404"
     delete:
@@ -360,6 +364,7 @@ components:
 
     CloudEvent:
       description: Event compliant with the CloudEvents specification
+      type: object
       required:
         - id
         - source


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* correction


#### What this PR does / why we need it:
Fixes the errors reported by the validation at the r2.2 automatic commonalities sync: [failed_validation](https://github.com/camaraproject/DedicatedNetworks/actions/runs/26743458600)

These errors are fixed:

[S-016] Schema must declare a type or combiner — 2 hits

code/API_definitions/dedicated-network-accesses.yaml:787:16 — [S-016] Missing 'type' at components.schemas.CloudEvent
code/API_definitions/dedicated-network.yaml:361:16 — [S-016] Missing 'type' at components.schemas.CloudEvent
[S-303] Write operation must be security-restricted — 1 hit

code/API_definitions/dedicated-network-areas.yaml:75:10 — [S-303] This write operation is not protected by any security scheme.
[S-307] Operation must document a 401 response — 1 hit

code/API_definitions/dedicated-network.yaml:197:17 — [S-307] Operation is missing responses[401].

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #

#### Special notes for reviewers:



#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
