### PR TITLE
Fix missing description warnings across the DN APIs 

### DIFF
--- a/code/API_definitions/dedicated-network-accesses.yaml
+++ b/code/API_definitions/dedicated-network-accesses.yaml
@@ -494,7 +494,7 @@ paths:
 components:
   securitySchemes:
     openId:
-      description: OpenID Connect authentication via discovery metadata
+      description: OpenID Connect authentication
       type: openIdConnect
       openIdConnectUrl: https://example.com/.well-known/openid-configuration
     notificationsBearerAuth:
@@ -616,7 +616,6 @@ components:
             $ref: "#/components/schemas/QosProfileName"
           minItems: 1
         defaultQosProfile:
-          description: (Optional) The default QOS profile for all devices included in the access. When absent, the defaultQosProfile of the network is used
           $ref: "#/components/schemas/QosProfileName"
         sink:
           description: The address to which events shall be delivered using the selected protocol.

--- a/code/API_definitions/dedicated-network-accesses.yaml
+++ b/code/API_definitions/dedicated-network-accesses.yaml
@@ -364,11 +364,13 @@ paths:
             $ref: "../common/CAMARA_common.yaml#/components/schemas/PerPage"
         - name: page
           in: query
+          description: |
+            Number of the page of access devices to return
           schema:
             $ref: "../common/CAMARA_common.yaml#/components/schemas/Page"
         - name: deviceStatus
           in: query
-          description: only access devices with this status are to be returned
+          description: Only access devices with this status are to be returned
           schema:
             $ref: "#/components/schemas/DeviceStatus"
       responses:
@@ -495,6 +497,14 @@ components:
       description: OpenID Connect authentication via discovery metadata
       type: openIdConnect
       openIdConnectUrl: https://example.com/.well-known/openid-configuration
+    notificationsBearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: "{$request.body#/sinkCredential.credentialType}"
+      description: |
+        Bearer token for notification delivery. Token format is determined
+        by `sinkCredential.credentialType` in the subscription request.
+
   parameters:
     x-device:
       name: x-device
@@ -603,18 +613,18 @@ components:
           description: (Optional) List of supported QOS profiles usable for the device(s). When absent, all QosProfiles of the network are supported. Only a subset of the QOS profiles of the network is allowed
           type: array
           items:
-            type: string
+            $ref: "#/components/schemas/QosProfileName"
           minItems: 1
         defaultQosProfile:
           description: (Optional) The default QOS profile for all devices included in the access. When absent, the defaultQosProfile of the network is used
-          type: string
+          $ref: "#/components/schemas/QosProfileName"
         sink:
           description: The address to which events shall be delivered using the selected protocol.
           type: string
           format: uri
           pattern: ^https:\/\/.+$
         sinkCredential:
-          $ref: '#/components/schemas/SinkCredential'
+          $ref: '../common/CAMARA_event_common.yaml#/components/schemas/SinkCredential'
       required:
         - networkId
 
@@ -832,100 +842,21 @@ components:
       type: string
       example: 'phonenumber="+123456789"'
 
-
-    SinkCredential:
-      description: A sink credential provides authentication or authorization information necessary to enable delivery of events to a target
-      type: object
-      properties:
-        credentialType:
-          description: The type of the credential
-          type: string
-          enum:
-            - PLAIN
-            - ACCESSTOKEN
-            - REFRESHTOKEN
-      discriminator:
-        propertyName: credentialType
-        mapping:
-          PLAIN: '#/components/schemas/PlainCredential'
-          ACCESSTOKEN: '#/components/schemas/AccessTokenCredential'
-          REFRESHTOKEN: '#/components/schemas/RefreshTokenCredential'
-      required:
-        - credentialType
-
-    PlainCredential:
-      type: object
-      description: A plain credential as a combination of an identifier and a secret.
-      allOf:
-        - $ref: '#/components/schemas/SinkCredential'
-        - type: object
-          required:
-            - identifier
-            - secret
-          properties:
-            identifier:
-              description: The identifier might be an account or username.
-              type: string
-            secret:
-              description: The secret might be a password or passphrase.
-              type: string
-
-    AccessTokenCredential:
-      type: object
-      description: An access token credential.
-      allOf:
-        - $ref: '#/components/schemas/SinkCredential'
-        - type: object
-          properties:
-            accessToken:
-              description: REQUIRED. An access token is a previously acquired token granting access to the target resource.
-              type: string
-            accessTokenExpiresUtc:
-              type: string
-              format: date-time
-              description: REQUIRED. An absolute UTC instant at which the token shall be considered expired.
-            accessTokenType:
-              description: REQUIRED. Type of the access token (See [OAuth 2.0](https://tools.ietf.org/html/rfc6749#section-7.1)). For the current version of the API the type MUST be set to `Bearer`.
-              type: string
-              enum:
-                - bearer
-          required:
-            - accessToken
-            - accessTokenExpiresUtc
-            - accessTokenType
-
-    RefreshTokenCredential:
-      type: object
-      description: An access token credential with a refresh token.
-      allOf:
-        - $ref: '#/components/schemas/SinkCredential'
-        - type: object
-          properties:
-            accessToken:
-              description: REQUIRED. An access token is a previously acquired token granting access to the target resource.
-              type: string
-            accessTokenExpiresUtc:
-              type: string
-              format: date-time
-              description: REQUIRED. An absolute UTC instant at which the token shall be considered expired.
-            accessTokenType:
-              description: REQUIRED. Type of the access token (See [OAuth 2.0](https://tools.ietf.org/html/rfc6749#section-7.1)).
-              type: string
-              enum:
-                - bearer
-            refreshToken:
-              description: REQUIRED. An refresh token credential used to acquire access tokens.
-              type: string
-            refreshTokenEndpoint:
-              type: string
-              format: uri
-              description: REQUIRED. A URL at which the refresh token can be traded for an access token.
-      required:
-        - accessToken
-        - accessTokenExpiresUtc
-        - accessTokenType
-        - refreshToken
-        - refreshTokenEndpoint
+    QosProfileName:
+      description: |
+        A unique name for identifying a specific QoS profile.
+        This may follow different formats depending on the service providers implementation.
+        Some options addresses:
+          - A UUID style string
+          - Support for predefined profiles QOS_S, QOS_M, QOS_L, and QOS_E
+          - A searchable descriptive name
+        The set of QoS Profiles that an operator is offering can be retrieved by means of the QoS Profile API.
+      type: string
+      example: QCI_1_voice
+      minLength: 3
+      maxLength: 256
+      format: string
+      pattern: "^[a-zA-Z0-9_.-]+$"
 
   responses:
     Generic400:

--- a/code/API_definitions/dedicated-network-areas.yaml
+++ b/code/API_definitions/dedicated-network-areas.yaml
@@ -141,6 +141,7 @@ paths:
             - dedicated-network-areas:areas:read
       parameters:
         - name: areaId
+          description: Identifier of the service area
           in: path
           required: true
           schema:
@@ -165,6 +166,7 @@ paths:
 components:
   securitySchemes:
     openId:
+      description: OpenID Connect authentication
       type: openIdConnect
       openIdConnectUrl: https://example.com/.well-known/openid-configuration
 

--- a/code/API_definitions/dedicated-network-areas.yaml
+++ b/code/API_definitions/dedicated-network-areas.yaml
@@ -333,20 +333,3 @@ components:
                 status: 404
                 code: NOT_FOUND
                 message: The specified resource is not found.
-
-    Generic410:
-      description: Gone
-      headers:
-        x-correlator:
-          $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            $ref: "../common/CAMARA_common.yaml#/components/schemas/ErrorInfo"
-          examples:
-            GENERIC_410_GONE:
-              description: Use in notifications flow to allow API Consumer to indicate that its callback is no longer available
-              value:
-                status: 410
-                code: GONE
-                message: Access to the target resource is no longer available.

--- a/code/API_definitions/dedicated-network-areas.yaml
+++ b/code/API_definitions/dedicated-network-areas.yaml
@@ -98,7 +98,8 @@ paths:
     post:
       tags:
         - Areas
-      summary: Retrieve dedicated network service areas, filtered by additional search criteria
+      summary: Retrieve network service areas, filtered by additional search criteria
+      description: Retrieve all network service areas matching the provided search criteria such as location, area overlap, name, or supported profiles.
       operationId: retrieveNetworkServiceAreas
       security:
         - openId:
@@ -112,7 +113,7 @@ paths:
         required: true
       responses:
         '200':
-          description: List of available dedicated network service areas
+          description: List of available network service areas
           content:
             application/json:
               schema:
@@ -132,7 +133,8 @@ paths:
     get:
       tags:
         - Areas
-      summary: Read a dedicated network service area
+      summary: Read a network service area
+      description: Read detailed information about a specific network service area identified by its areaId.
       operationId: readNetworkServiceArea
       security:
         - openId:
@@ -146,7 +148,7 @@ paths:
         - $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
       responses:
         '200':
-          description: Information about the dedicated network service area
+          description: Information about the network service area
           content:
             application/json:
               schema:
@@ -169,7 +171,9 @@ components:
   schemas:
 
     NetworkProfileId:
+      description: Network profile id in UUID format
       type: string
+      format: uuid
 
     QosProfileName:
       description: |
@@ -188,6 +192,7 @@ components:
       pattern: "^[a-zA-Z0-9_.-]+$"
 
     ServiceAreaId:
+      description: Unique identifier of a network service area
       type: string
       format: uuid
 
@@ -202,6 +207,7 @@ components:
         coveringArea:
           $ref: "../common/CAMARA_common.yaml#/components/schemas/Area"
         byName:
+          description: Only service areas with a name matching exactly this parameter are to be returned
           type: string
         byNetworkProfileId:
           $ref: "#/components/schemas/NetworkProfileId"
@@ -209,13 +215,15 @@ components:
           $ref: "#/components/schemas/QosProfileName"
 
     ServiceArea:
-      description: Common attributes of a service area, i.e. where the dedicated network service is supported
+      description: Common attributes of a service area, i.e. where the network service is supported
       properties:
         id:
           $ref: '#/components/schemas/ServiceAreaId'
         name:
+          description: A readable name of the service area (need not be unique)
           type: string
         description:
+          description: A readable description of the service area
           type: string
         area:
           $ref: "../common/CAMARA_common.yaml#/components/schemas/Area"

--- a/code/API_definitions/dedicated-network-profiles.yaml
+++ b/code/API_definitions/dedicated-network-profiles.yaml
@@ -87,6 +87,7 @@ paths:
       tags:
         - Profiles
       summary: Read dedicated network profiles
+      description: Read all available network profiles, optionally filtered by name.
       operationId: readNetworkProfiles
       security:
         - openId:
@@ -119,12 +120,14 @@ paths:
       tags:
         - Profiles
       summary: Read a dedicated network profile
+      description: Read detailed information about a specific network profile identified by its profileId.
       operationId: readNetworkProfile
       security:
         - openId:
             - dedicated-network-profiles:profiles:read
       parameters:
         - name: profileId
+          description: Identifier of the network profile
           in: path
           required: true
           schema:
@@ -149,6 +152,7 @@ paths:
 components:
   securitySchemes:
     openId:
+      description: OpenID Connect authentication
       type: openIdConnect
       openIdConnectUrl: https://example.com/.well-known/openid-configuration
   schemas:
@@ -159,6 +163,7 @@ components:
       format: uuid
 
     NetworkProfile:
+      description: A predefined set of network capabilities and performance characteristics for a dedicated network
       type: object
       properties:
         id:
@@ -167,6 +172,7 @@ components:
           description: A human-readable name to describe the network profile
           type: string
         maxNumberOfDevices:
+          description: The maximum number of devices that can simultaneously use and share the dedicated network under this profile up to the limits set by the profile's performance characteristics
           type: integer
         aggregatedUlThroughput:
           $ref: "#/components/schemas/BitRate"

--- a/code/API_definitions/dedicated-network-profiles.yaml
+++ b/code/API_definitions/dedicated-network-profiles.yaml
@@ -359,29 +359,3 @@ components:
                 status: 404
                 code: IDENTIFIER_NOT_FOUND
                 message: Device identifier not found.
-
-    Generic410:
-      description: Gone
-      headers:
-        x-correlator:
-          $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "../common/CAMARA_common.yaml#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 410
-                  code:
-                    enum:
-                      - GONE
-          examples:
-            GENERIC_410_GONE:
-              description: Use in notifications flow to allow API Consumer to indicate that its callback is no longer available
-              value:
-                status: 410
-                code: GONE
-                message: Access to the target resource is no longer available.

--- a/code/API_definitions/dedicated-network.yaml
+++ b/code/API_definitions/dedicated-network.yaml
@@ -195,12 +195,14 @@ paths:
       tags:
         - Networks
       summary: Get the current information about a dedicated network
+      description: Read the current status and configuration of a specific dedicated network identified by its networkId.
       operationId: readNetwork
       security:
         - openId:
             - dedicated-network:networks:read
       parameters:
         - name: networkId
+          description: Identifier of the dedicated network
           in: path
           required: true
           schema:
@@ -225,12 +227,14 @@ paths:
       tags:
         - Networks
       summary: Delete a dedicated network
+      description: Delete a dedicated network identified by its networkId.
       operationId: deleteNetwork
       security:
         - openId:
             - dedicated-network:networks:delete
       parameters:
         - name: networkId
+          description: Identifier of the dedicated network
           in: path
           required: true
           schema:
@@ -251,13 +255,16 @@ paths:
 components:
   securitySchemes:
     openId:
+      description: OpenID Connect authentication
       type: openIdConnect
       openIdConnectUrl: https://example.com/.well-known/openid-configuration
     notificationsBearerAuth:
-      description: Bearer authentication for notifications
       type: http
       scheme: bearer
-      bearerFormat: "{$request.body#sinkCredential.credentialType}"
+      bearerFormat: "{$request.body#/sinkCredential.credentialType}"
+      description: |
+        Bearer token for notification delivery. Token format is determined
+        by `sinkCredential.credentialType` in the subscription request.
 
   schemas:
 
@@ -288,6 +295,7 @@ components:
       pattern: "^[a-zA-Z0-9_.-]+$"
 
     ServiceAreaId:
+      description: Unique identifier of a network service area
       type: string
       format: uuid
 
@@ -312,7 +320,7 @@ components:
           format: uri
           pattern: ^https:\/\/.+$
         sinkCredential:
-          $ref: '#/components/schemas/SinkCredential'
+          $ref: '../common/CAMARA_event_common.yaml#/components/schemas/SinkCredential'
       required:
         - serviceTime
         - serviceAreaId
@@ -397,6 +405,7 @@ components:
             - data
 
     ServiceTime:
+      description: The time window during which the dedicated network shall be available
       type: object
       properties:
         start:
@@ -410,98 +419,6 @@ components:
       required:
         - start
         - end
-
-    SinkCredential:
-      type: object
-      properties:
-        credentialType:
-          type: string
-          enum:
-            - PLAIN
-            - ACCESSTOKEN
-            - REFRESHTOKEN
-      discriminator:
-        propertyName: credentialType
-        mapping:
-          PLAIN: '#/components/schemas/PlainCredential'
-          ACCESSTOKEN: '#/components/schemas/AccessTokenCredential'
-          REFRESHTOKEN: '#/components/schemas/RefreshTokenCredential'
-      required:
-        - credentialType
-
-    PlainCredential:
-      type: object
-      description: A plain credential as a combination of an identifier and a secret.
-      allOf:
-        - $ref: '#/components/schemas/SinkCredential'
-        - type: object
-          required:
-            - identifier
-            - secret
-          properties:
-            identifier:
-              description: The identifier might be an account or username.
-              type: string
-            secret:
-              description: The secret might be a password or passphrase.
-              type: string
-
-    AccessTokenCredential:
-      type: object
-      description: An access token credential.
-      allOf:
-        - $ref: '#/components/schemas/SinkCredential'
-        - type: object
-          properties:
-            accessToken:
-              description: REQUIRED. An access token is a previously acquired token granting access to the target resource.
-              type: string
-            accessTokenExpiresUtc:
-              type: string
-              format: date-time
-              description: REQUIRED. An absolute UTC instant at which the token shall be considered expired.
-            accessTokenType:
-              description: REQUIRED. Type of the access token (See [OAuth 2.0](https://tools.ietf.org/html/rfc6749#section-7.1)). For the current version of the API the type MUST be set to `Bearer`.
-              type: string
-              enum:
-                - bearer
-          required:
-            - accessToken
-            - accessTokenExpiresUtc
-            - accessTokenType
-
-    RefreshTokenCredential:
-      type: object
-      description: An access token credential with a refresh token.
-      allOf:
-        - $ref: '#/components/schemas/SinkCredential'
-        - type: object
-          properties:
-            accessToken:
-              description: REQUIRED. An access token is a previously acquired token granting access to the target resource.
-              type: string
-            accessTokenExpiresUtc:
-              type: string
-              format: date-time
-              description: REQUIRED. An absolute UTC instant at which the token shall be considered expired.
-            accessTokenType:
-              description: REQUIRED. Type of the access token (See [OAuth 2.0](https://tools.ietf.org/html/rfc6749#section-7.1)).
-              type: string
-              enum:
-                - bearer
-            refreshToken:
-              description: REQUIRED. An refresh token credential used to acquire access tokens.
-              type: string
-            refreshTokenEndpoint:
-              type: string
-              format: uri
-              description: REQUIRED. A URL at which the refresh token can be traded for an access token.
-      required:
-        - accessToken
-        - accessTokenExpiresUtc
-        - accessTokenType
-        - refreshToken
-        - refreshTokenEndpoint
 
   responses:
     Generic400:

--- a/code/API_definitions/dedicated-network.yaml
+++ b/code/API_definitions/dedicated-network.yaml
@@ -86,6 +86,7 @@ paths:
       tags:
         - Networks
       summary: Get a list of dedicated networks
+      description: List all available dedicated networks, optionally filtered by name.
       operationId: listNetworks
       security:
         - openId:
@@ -117,6 +118,7 @@ paths:
       tags:
         - Networks
       summary: Request to create a dedicated network
+      description: Create a dedicated network with the given configuration, including service time, service area, and a network profile or QoS profile.
       operationId: createNetwork
       security:
         - openId:


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* correction



#### What this PR does / why we need it:
This PR fixes all the outstanding 'missing description' validation warnings across the DN APIs. Additionally it addresses relevant 'unused component' hints.

#### Which issue(s) this PR fixes:

[S-009] Parameter must have a description — 5 hits

code/API_definitions/dedicated-network-accesses.yaml:365:11 — [S-009] Parameter description is missing or empty: "[1].description" property must be truthy
code/API_definitions/dedicated-network-areas.yaml:141:11 — [S-009] Parameter description is missing or empty: "[0].description" property must be truthy
code/API_definitions/dedicated-network-profiles.yaml:127:11 — [S-009] Parameter description is missing or empty: "[0].description" property must be truthy
code/API_definitions/dedicated-network.yaml:203:11 — [S-009] Parameter description is missing or empty: "[0].description" property must be truthy
code/API_definitions/dedicated-network.yaml:233:11 — [S-009] Parameter description is missing or empty: "[0].description" property must be truthy

[S-031] Array items must have a description — 2 hits

code/API_definitions/dedicated-network-accesses.yaml:605:17 — [S-031] Array items must have a description
code/API_definitions/dedicated-network-areas.yaml:171:22 — [S-031] Array items must have a description

[S-014] Operation must have a description — 8 hits

code/API_definitions/dedicated-network-areas.yaml:98:10 — [S-014] Functionality method description Warning: Each method should have description.
code/API_definitions/dedicated-network-areas.yaml:132:9 — [S-014] Functionality method description Warning: Each method should have description.
code/API_definitions/dedicated-network-profiles.yaml:86:9 — [S-014] Functionality method description Warning: Each method should have description.
code/API_definitions/dedicated-network-profiles.yaml:118:9 — [S-014] Functionality method description Warning: Each method should have description.
code/API_definitions/dedicated-network.yaml:85:9 — [S-014] Functionality method description Warning: Each method should have description.
code/API_definitions/dedicated-network.yaml:116:10 — [S-014] Functionality method description Warning: Each method should have description.
code/API_definitions/dedicated-network.yaml:194:9 — [S-014] Functionality method description Warning: Each method should have description.
code/API_definitions/dedicated-network.yaml:224:12 — [S-014] Functionality method description Warning: Each method should have description.
[S-215] Operation must have a description — 8 hits

code/API_definitions/dedicated-network-areas.yaml:98:10 — [S-215] Operation "description" must be present and non-empty string.
code/API_definitions/dedicated-network-areas.yaml:132:9 — [S-215] Operation "description" must be present and non-empty string.
code/API_definitions/dedicated-network-profiles.yaml:86:9 — [S-215] Operation "description" must be present and non-empty string.
code/API_definitions/dedicated-network-profiles.yaml:118:9 — [S-215] Operation "description" must be present and non-empty string.
code/API_definitions/dedicated-network.yaml:85:9 — [S-215] Operation "description" must be present and non-empty string.
code/API_definitions/dedicated-network.yaml:116:10 — [S-215] Operation "description" must be present and non-empty string.
code/API_definitions/dedicated-network.yaml:194:9 — [S-215] Operation "description" must be present and non-empty string.
code/API_definitions/dedicated-network.yaml:224:12 — [S-215] Operation "description" must be present and non-empty string.

[S-011] Schema property must have a description — 14 hits

code/API_definitions/dedicated-network-areas.yaml:165:12 — [S-011] Property description is missing or empty: "openId.description" property must be truthy
code/API_definitions/dedicated-network-areas.yaml:171:22 — [S-011] Property description is missing or empty: "NetworkProfileId.description" property must be truthy
code/API_definitions/dedicated-network-areas.yaml:190:19 — [S-011] Property description is missing or empty: "ServiceAreaId.description" property must be truthy
code/API_definitions/dedicated-network-areas.yaml:204:16 — [S-011] Property description is missing or empty: "byName.description" property must be truthy
code/API_definitions/dedicated-network-areas.yaml:216:14 — [S-011] Property description is missing or empty: "name.description" property must be truthy
code/API_definitions/dedicated-network-areas.yaml:218:21 — [S-011] Property description is missing or empty: "description.description" property must be truthy
code/API_definitions/dedicated-network-profiles.yaml:151:12 — [S-011] Property description is missing or empty: "openId.description" property must be truthy
code/API_definitions/dedicated-network-profiles.yaml:161:20 — [S-011] Property description is missing or empty: "NetworkProfile.description" property must be truthy
code/API_definitions/dedicated-network-profiles.yaml:169:28 — [S-011] Property description is missing or empty: "maxNumberOfDevices.description" property must be truthy
code/API_definitions/dedicated-network.yaml:253:12 — [S-011] Property description is missing or empty: "openId.description" property must be truthy
code/API_definitions/dedicated-network.yaml:290:19 — [S-011] Property description is missing or empty: "ServiceAreaId.description" property must be truthy
code/API_definitions/dedicated-network.yaml:399:17 — [S-011] Property description is missing or empty: "ServiceTime" property must be truthy
code/API_definitions/dedicated-network.yaml:414:20 — [S-011] Property description is missing or empty: "SinkCredential" property must be truthy
code/API_definitions/dedicated-network.yaml:417:24 — [S-011] Property description is missing or empty: "credentialType.description" property must be truthy

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #

#### Special notes for reviewers:



#### Changelog input

```
Addressing the "missing description" warnings and the "Component may be unused" hints.

```

#### Additional documentation 

This section can be blank.



```
docs

```
